### PR TITLE
Adding new config var for ckeditor

### DIFF
--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -13,4 +13,6 @@ $ ->
   Selfstarter.admin.init()
   Selfstarter.campaigns.init()
   Selfstarter.theme.init()
+  
+CKEDITOR.config.allowedContent = true
 


### PR DESCRIPTION
By default, CKEditor filters some tags for security.  Since the site owners are the only ones with access to the ckeditor inputs, we can go ahead and turn off this default filtering behavior to allow maximum flexibility in uploading HTML content.
