### PR TITLE
Adding visibility flag to rewards

### DIFF
--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -1,5 +1,5 @@
 class Reward < ActiveRecord::Base
-  attr_accessible :title, :description, :delivery_date, :number, :price, :campaign_id
+  attr_accessible :title, :description, :delivery_date, :number, :price, :campaign_id, :visible_flag
 
    validates :title, :description, :delivery_date, :price, presence: true
 
@@ -16,6 +16,10 @@ class Reward < ActiveRecord::Base
 
   def unlimited?
     self.number.nil? || self.number == 0
+  end
+
+  def visible?
+    self.visible_flag
   end
 
 end

--- a/app/views/campaigns/checkout_amount.html.erb
+++ b/app/views/campaigns/checkout_amount.html.erb
@@ -60,6 +60,7 @@
                   <a class="reward_edit" href="#" style="display:none">edit</a>
               </li>
               <% @campaign.rewards.order("price ASC").each do |reward| %>
+              <% if reward.visible? %>
                 <li class="reward_option <%= raw('active') unless reward.sold_out? %> <%= ((@reward.id == reward.id) ? raw('selected') : raw('hide')) if @reward %> clearfix" data-id="<%= reward.id %>" data-price="<%= short_price(reward.price) %>">
                   <input class="reward_input" type="radio" name="reward" value="<%= reward.id %>" <%= raw('disabled') if reward.sold_out? %><%= raw('checked="checked"') if @reward && @reward.id == reward.id %>>
                   <label class="price">$<%= short_price(reward.price) %> +</label>
@@ -74,6 +75,7 @@
                   </div>
                   <a class="reward_edit" href="#" style="<%= 'display:none' unless @reward && @reward.id == reward.id %>">edit</a>
                 </li>
+              <% end %>
               <% end %>
             </ul>
             </div>

--- a/app/views/theme/views/campaign.html.erb
+++ b/app/views/theme/views/campaign.html.erb
@@ -157,6 +157,7 @@
           <h3><%= @campaign.reward_reference.pluralize.titleize %></h3>
           <ul>
             <% @campaign.rewards.order("price ASC").each do |reward| %>
+            <% if reward.visible? %>
               <li>
                 <a href="<%= url_for(checkout_amount_path(@campaign, reward: reward.id)) %>"  onclick="<%= 'return false' if reward.sold_out? %>" class="<%= 'disabled' if reward.sold_out? %>">
                   <p class="price">$<%= number_with_precision(reward.price, precision: (reward.price*100%100==0.0 ? 0 : 2)) %></p>
@@ -168,6 +169,7 @@
                   </p>
                 </a>
               </li>
+            <% end %>
             <% end %>
           </ul>
         </div>

--- a/db/migrate/20130812230857_add_visible_flag_to_rewards.rb
+++ b/db/migrate/20130812230857_add_visible_flag_to_rewards.rb
@@ -1,0 +1,5 @@
+class AddVisibleFlagToRewards < ActiveRecord::Migration
+  def change
+    add_column :rewards, :visible_flag, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130703163000) do
+ActiveRecord::Schema.define(:version => 20130812230857) do
 
   create_table "campaigns", :force => true do |t|
     t.string   "name"
@@ -132,8 +132,9 @@ ActiveRecord::Schema.define(:version => 20130703163000) do
     t.integer  "number"
     t.float    "price"
     t.integer  "campaign_id"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
+    t.datetime "created_at",                      :null => false
+    t.datetime "updated_at",                      :null => false
+    t.boolean  "visible_flag",  :default => true, :null => false
   end
 
   create_table "settings", :force => true do |t|


### PR DESCRIPTION
This adds the backend plumbing for a visiblity flag on rewards.  Also adds the conditional on the views to only show rewards that have visible set to true.  

This PR does not yet add the capability to set a reward as visible/invisible from the backend admin...more discussion needed on that.  For now, updating reward visibility will need to be done from the console
