### PR TITLE
Calculating campaign stats locally

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -68,6 +68,18 @@ class Campaign < ActiveRecord::Base
     (self.payment_type != 'fixed' && self.rewards.length > 0)
   end
 
+  def raised_amount
+    payments.where("payments.status!='refunded'").sum(:amount)/100.0
+  end
+
+  def number_of_contributions
+    payments.where("payments.status!='refunded'").count
+  end
+
+  def tilt_percent
+    (raised_amount / goal_dollars) * 100.0
+  end
+
   private
 
   def set_min_amount

--- a/app/views/theme/views/campaign.html.erb
+++ b/app/views/theme/views/campaign.html.erb
@@ -44,11 +44,11 @@
 
           <% if @campaign.goal_type == 'dollars' %>
           <li class="stats" id="backers">
-            <%= number_with_delimiter @campaign.stats_number_of_contributions.to_i, :delimiter => "," %>
-            <span><%= @campaign.contributor_reference.pluralize(@campaign.stats_number_of_contributions.to_i) %></span>
+            <%= number_with_delimiter @campaign.number_of_contributions.to_i, :delimiter => "," %>
+            <span><%= @campaign.contributor_reference.pluralize(@campaign.number_of_contributions.to_i) %></span>
           </li>
           <li class="stats">
-            <%= number_to_currency @campaign.stats_raised_amount.ceil, :precision => 0 %>
+            <%= number_to_currency @campaign.raised_amount.ceil, :precision => 0 %>
             <span>of <%= number_to_currency @campaign.goal_dollars.ceil, :precision => 0 %></span>
           </li>
           <% else %>
@@ -71,16 +71,16 @@
           <% end %>
         </ul>
 
-        <% if @campaign.stats_raised_amount < @campaign.goal_dollars %>
+        <% if @campaign.raised_amount < @campaign.goal_dollars %>
           <div id='progress_bg' class='small'>
-            <div id='progress' class='' style='width: <%= @campaign.stats_tilt_percent.to_i %>%;'>
+            <div id='progress' class='' style='width: <%= @campaign.tilt_percent.to_i %>%;'>
             </div>
           </div>
         <% else %>
           <div id="progress_bg">
             <div id="progress">
             </div>
-            <div id='progress_text'><%= @campaign.stats_tilt_percent.ceil %>% <%= @campaign.progress_text %></div>
+            <div id='progress_text'><%= @campaign.tilt_percent.ceil %>% <%= @campaign.progress_text %></div>
           </div>
         <% end %>
 

--- a/app/views/theme/views/homepage.html.erb
+++ b/app/views/theme/views/homepage.html.erb
@@ -34,9 +34,9 @@
               <%= truncate(campaign.name, length: 50) %>
             </p>
 
-            <% if campaign.stats_raised_amount.to_f/100 < campaign.goal_dollars.to_f %>
+            <% if campaign.raised_amount.to_f/100 < campaign.goal_dollars.to_f %>
               <div id='progress_bg'>
-                <div id='progress' class='' style='width: <%= campaign.stats_tilt_percent.nil? ? 0 : campaign.stats_tilt_percent.ceil %>%;'>
+                <div id='progress' class='' style='width: <%= campaign.tilt_percent.nil? ? 0 : campaign.tilt_percent.ceil %>%;'>
                 </div>
               </div>
             <% else %>
@@ -59,7 +59,7 @@
 
             <p class="numbers pull-right" style="text-align:right">
               <% if campaign.goal_type == 'dollars' %>
-              <strong>$<%= campaign.stats_raised_amount.ceil %></strong><br/>
+              <strong>$<%= campaign.raised_amount.ceil %></strong><br/>
               <%= campaign.progress_text %>
               <% else %>
                <strong><%= campaign.orders %></strong><br/>


### PR DESCRIPTION
This PR introduces methods on the campaign model that calculate campaign stats based on the Crowdhoster site's local data, as opposed to relying on the stats values returned by the API.  By removing the dependency, we provide more flexibility with campaign data.
