### PR TITLE
Adding rake task for synching payment data with the crowtilt api

### DIFF
--- a/lib/tasks/sync_payments.rake
+++ b/lib/tasks/sync_payments.rake
@@ -1,0 +1,50 @@
+namespace :ch do
+
+  # To run this rake task, you'll need to specify a campaign ID as well as which rails environment you are targeting
+  # Example:
+  # $ foreman run rake ch:sync_crowdtilt_payments CAMPAIGN_ID=CMP3A7758DE00B911E38B6F99339B09C131 RAILS_ENV=production
+
+  desc "Synchronize payment data on the API with the local payment data"
+  task :sync_crowdtilt_payments => :environment do
+    campaign = Campaign.find_by_ct_campaign_id(ENV['CAMPAIGN_ID'])
+    if campaign
+      puts "Synching payments for #{campaign.name}"
+      Rails.env.production? ? Crowdtilt.production : Crowdtilt.sandbox
+      begin
+        response = Crowdtilt.get("campaigns/#{campaign.ct_campaign_id}/payments")
+      rescue => exception
+        puts exception.message and return
+      end
+      ct_payments = response['payments']
+      pages = response['pagination']['total_pages']
+
+      counter = 1
+
+      for x in 1..pages
+        if x >1
+          begin
+            response = Crowdtilt.get("campaigns/#{campaign.ct_campaign_id}/payments?page=#{x}")
+          rescue => exception
+            puts exception.message and return
+          end
+          ct_payments = response['payments']
+        end
+
+        ct_payments.each do |ct_payment|
+          puts "#{counter}: Synching payment #{ct_payment['id']} | Status: #{ct_payment['status']}"
+          payment = Payment.find_by_ct_payment_id(ct_payment['id'])
+          if payment
+            payment.update_api_data(ct_payment)
+            payment.save
+            counter+=1
+          else
+            puts "Payment not found (#{ct_payment['id']})"
+          end
+        end
+      end
+    else
+      puts "Campaign Not Found (#{ENV['CAMPAIGN_ID']})"
+    end
+  end
+
+end


### PR DESCRIPTION
When a campaign tilts (hits its goal), the crowdtilt api automatically charges everyone's card in the background.  Successful charges become status 'charged', while unsuccessful charges become status 'rejected'.  Rejected payments usually occur due to long-running campaigns, in which initial card authorizations have a chance to expire before the campaign hits its goal.

One issue with Crowdhoster is that the payment information that is stored locally on the app is not updated when the  Crowdtilt API performs the bulk set of transactions in the background.

This rake task is a first step toward keeping the data better in sync.  After a campaign tilts, this rake task can be run to individually update each local payment record with the corresponding data from the crowdtilt API.  This will allow the site owner to clearly see which cards were successfully "charged" and which were "rejected"
