### PR TITLE
Adding custom billing statment text

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -136,6 +136,7 @@ class CampaignsController < ApplicationController
         admin_fee_amount: admin_fee_amount,
         user_id: ct_user_id,
         card_id: ct_card_id,
+        billing_statement_text: @settings.billing_statement_text,
         metadata: {
           fullname: fullname,
           email: email,
@@ -147,6 +148,7 @@ class CampaignsController < ApplicationController
       @campaign.production_flag ? Crowdtilt.production : Crowdtilt.sandbox
       response = Crowdtilt.post('/campaigns/' + @campaign.ct_campaign_id + '/payments', {payment: payment})
     rescue => exception
+      logger.debug "Error with post to /payments: #{exception.message}"
       redirect_to checkout_amount_url(@campaign), flash: { error: exception.to_s }
       return
     end

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -20,6 +20,10 @@ class Settings < ActiveRecord::Base
   has_attached_file :facebook_image,
                     styles: { thumb: "100x100#" }
 
+  def billing_statement_text
+    ('CH*' + site_name.upcase)[0, 22]
+  end
+
   private
 
   def set_api_key

--- a/app/views/admin/admin_website.html.erb
+++ b/app/views/admin/admin_website.html.erb
@@ -11,7 +11,7 @@
       <legend>Basic Information</legend>
 
         <div class="field clearfix">
-          <p class="explanation">This'll be both the page title (for SEO) and the name in the header</p>
+          <p class="explanation">This will be used as the page title (for SEO) and the name in the header. Your site name is also what contributors will see on their credit card statements.</p>
           <label>Site Name</label>
             <%= f.text_field :site_name %>
         </div>

--- a/app/views/campaigns/checkout_confirmation.html.erb
+++ b/app/views/campaigns/checkout_confirmation.html.erb
@@ -33,7 +33,8 @@
         <%= @payment.additional_info %>
         <br/><br/>
       <% end %>
-      <strong>ID:</strong><br/> <%= @payment.ct_payment_id %><br/><br/>
+      <strong>Payment ID:</strong><br/> <%= @payment.ct_payment_id %><br/><br/>
+      <strong>Charge will appear on your statement as:</strong><br/> <%= 'BAL*' + @settings.billing_statement_text %><br/><br/>
       <p class="center">An email confirmation was sent to <%= @payment.email %></p>
       </p>
     </div>

--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -4,10 +4,11 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
   </head>
   <body>
-    <h4><%= @settings.site_name %></h4>
+    <p style="font-size: 16px; color: black"><%= @settings.site_name %></p>
     <hr>
+    <br/>
     <%= yield %>
-    <br/><br/>
+    <br/>
     <hr>
     <p style="color: black; text-align: center; text-decoration:none;">&nbsp;&nbsp;<a style="text-decoration: none; color: black" href="http://www.crowdhoster.com" target="_blank">A Crowdhoster Site</a> &nbsp;<img height="15px;" src="https://crowdhoster-emails.s3.amazonaws.com/crowdtiltcircle.png">&nbsp; <a style="text-decoration:none; color: black" href="http://www.crowdtilt.com" target="_blank">Powered by Crowdtilt</a></p>
     <p style="text-align: center;"><a style="text-decoration:none;" href="http://www.crowdhoster.com">[Start your own campaign]</a></p>

--- a/app/views/user_mailer/payment_confirmation.html.erb
+++ b/app/views/user_mailer/payment_confirmation.html.erb
@@ -1,4 +1,4 @@
-<br/>
+<p style="font-size: 14px; line-height: 18px; color: #6b6b6b">
 Hi <%= @payment.fullname.split(' ')[0] %>,
 
 <br/><br/>
@@ -31,7 +31,9 @@ Card: <%= @payment.card_type %> ************<%= @payment.card_last_four %><br/>
   <%= @payment.additional_info %>
   <br/>
 <% end %>
-Payment ID: <%= @payment.ct_payment_id %>
+<br/>
+Payment ID: <%= @payment.ct_payment_id %><br/>
+Charge will appear as: <%= 'BAL*' + @settings.billing_statement_text %>
 
 <br/><br/>
 
@@ -43,3 +45,4 @@ Your credit card will only be charged if this campaign reaches its goal. In the 
 <br/></br>
 
 Thanks for your support!
+</p>

--- a/app/views/user_mailer/payment_confirmation.text.erb
+++ b/app/views/user_mailer/payment_confirmation.text.erb
@@ -1,8 +1,6 @@
 Hi <%= @payment.fullname.split(' ')[0] %>,
 
-
 This email is a confirmation of your $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> payment to <%= @campaign.name %>. If you have any questions about this campaign, please contact <%= @settings.reply_to_email %>.
-
 
 Payment Details:
 
@@ -31,7 +29,9 @@ Card: <%= @payment.card_type %> ************<%= @payment.card_last_four %>
   <%= @payment.additional_info %>
 
 <% end %>
+
 Payment ID: <%= @payment.ct_payment_id %>
+Charge will appear as: <%= 'BAL*' + @settings.billing_statement_text %>
 
 Please keep this email as your receipt.
 <% if !@campaign.is_tilted %>


### PR DESCRIPTION
This PR includes a nice upgrade that passes the Site Name through as the text that appears on a contributor's bank statement.  Hopefully this will alleviate some confusion with where charges are coming from, as now each Crowdhoster site will have it's unique name actually show up on the statement.

Also updates the confirmation page and receipt email to include what to expect on the credit card statement.
