### PR TITLE
Small tweak to billing statement text

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -21,7 +21,7 @@ class Settings < ActiveRecord::Base
                     styles: { thumb: "100x100#" }
 
   def billing_statement_text
-    ('CH*' + site_name.upcase)[0, 22]
+    ('CH ' + site_name.upcase)[0, 18]
   end
 
   private


### PR DESCRIPTION
Turns out we need to truncate to 18 characters instead of 22, and can't use an \* character :)
