### PR TITLE
Adding new mailgun field to the settings table to support mailgun routes

### DIFF
--- a/db/migrate/20130910234120_add_mailgun_route_idto_settings.rb
+++ b/db/migrate/20130910234120_add_mailgun_route_idto_settings.rb
@@ -1,0 +1,5 @@
+class AddMailgunRouteIdtoSettings < ActiveRecord::Migration
+  def change
+    add_column :settings, :mailgun_route_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130830004146) do
+ActiveRecord::Schema.define(:version => 20130910234120) do
 
   create_table "campaigns", :force => true do |t|
     t.string   "name"
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(:version => 20130830004146) do
     t.string   "api_key"
     t.string   "reply_to_email",              :default => "team@crowdhoster.com", :null => false
     t.text     "custom_js"
+    t.string   "mailgun_route_id"
   end
 
   create_table "users", :force => true do |t|


### PR DESCRIPTION
The mailgun routes feature will let us get more robust with how we handle email.  Adding this field is a forward-looking addition to the codebase should we be able to integrate routes in the near future.
