### PR TITLE
Making the app useable with only sandbox ct keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,6 @@
 APP_NAME=myawesomeapp
 CROWDTILT_SANDBOX_KEY=crowdtiltsandboxkey
 CROWDTILT_SANDBOX_SECRET=crowdtiltsandboxsecret
-CROWDTILT_PRODUCTION_KEY=crowdtiltproductionkey
-CROWDTILT_PRODUCTION_SECRET=crowdtiltproductionsecret
 ENABLE_ASSET_SYNC=true
 AWS_BUCKET=awsbucket
 AWS_ACCESS_KEY_ID=awsaccesskey

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ Important: Your ```APP_NAME``` must not have a space in it. Underscores and hype
 APP_NAME=myawesomeapp
 CROWDTILT_SANDBOX_KEY=crowdtiltsandboxkey
 CROWDTILT_SANDBOX_SECRET=crowdtiltsandboxsecret
-CROWDTILT_PRODUCTION_KEY=crowdtiltproductionkey
-CROWDTILT_PRODUCTION_SECRET=crowdtiltproductionsecret
 ENABLE_ASSET_SYNC=true
 AWS_BUCKET=awsbucket
 AWS_ACCESS_KEY_ID=awsaccesskey

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,21 +59,6 @@ class ApplicationController < ActionController::Base
             email: (Rails.configuration.crowdhoster_app_name + '-admin@crowdhoster.com')
           }
           sandbox_admin = Crowdtilt.post('/users', {user: sandbox_admin})
-
-          Crowdtilt.production
-          production_guest = {
-            firstname: 'Crowdhoster',
-            lastname: (Rails.configuration.crowdhoster_app_name + '-guest'),
-            email: (Rails.configuration.crowdhoster_app_name + '-guest@crowdhoster.com')
-          }
-          production_guest = Crowdtilt.post('/users', {user: production_guest})
-
-          production_admin = {
-            firstname: 'Crowdhoster',
-            lastname: (Rails.configuration.crowdhoster_app_name + '-admin'),
-            email: (Rails.configuration.crowdhoster_app_name + '-admin@crowdhoster.com')
-          }
-          production_admin = Crowdtilt.post('/users', {user: production_admin})
         rescue => exception
           @settings.update_attribute :initialized_flag, false
           sign_out current_user
@@ -82,8 +67,6 @@ class ApplicationController < ActionController::Base
         else
           @settings.update_attribute :ct_sandbox_guest_id, sandbox_guest['user']['id']
           @settings.update_attribute :ct_sandbox_admin_id, sandbox_admin['user']['id']
-          @settings.update_attribute :ct_production_guest_id, production_guest['user']['id']
-          @settings.update_attribute :ct_production_admin_id, production_admin['user']['id']
         end
 
 

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -140,7 +140,7 @@ class CampaignsController < ApplicationController
           additional_info: additional_info
         }
       }
-      @campaign.production_flag ? Crowdtilt.production : Crowdtilt.sandbox
+      @campaign.production_flag ? Crowdtilt.production(@settings) : Crowdtilt.sandbox
 
       logger.info "CROWDTILT API REQUEST: /campaigns/#{@campaign.ct_campaign_id}/payments"
       logger.info payment

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -22,7 +22,7 @@ class Campaign < ActiveRecord::Base
   validates :name, :expiration_date, presence: true
   validates :min_payment_amount, numericality: { greater_than_or_equal_to: 1.0 }
   validates :fixed_payment_amount, numericality: { greater_than_or_equal_to: 1.0 }
-  validate :expiration_date_cannot_be_in_the_past
+  validate :expiration_date_cannot_be_in_the_past, :payments_can_be_activated
 
   before_validation { main_image.clear if main_image_delete == '1' }
   before_validation { video_placeholder.clear if video_placeholder_delete == '1' }
@@ -92,6 +92,12 @@ class Campaign < ActiveRecord::Base
     if self.expiration_date_changed? && !self.expiration_date.blank? && self.expiration_date < Time.current
       errors.add(:expiration_date, "can't be in the past")
     end
+  end
+
+  def payments_can_be_activated
+      if self.production_flag && !Settings.find_by_id(1).payments_activated?
+        errors.add(:base, "cannot activate payments")
+      end
   end
 
 end

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -10,7 +10,7 @@
   <li class="<%= campaigns %>">
     <%= link_to "Campaigns", admin_campaigns_path, :class => 'show_loader', :'data-loader' => "admin_header" %>
   </li>
-  <li class="<%= bank %>">
-    <%= link_to "Bank Setup", admin_bank_setup_path, :class => 'show_loader', :'data-loader' => "admin_header" %>
+  <li class="<%= payments %>">
+    <%= link_to "Payment Settings", admin_processor_setup_path, :class => 'show_loader', :'data-loader' => "admin_header" %>
   </li>
 </ul>

--- a/app/views/admin/admin_bank_setup.html.erb
+++ b/app/views/admin/admin_bank_setup.html.erb
@@ -1,7 +1,12 @@
 <div id="admin">
   <div class="container content_box clearfix">
 
-  <%= render 'admin/header', website: '', campaigns: '', bank: 'active' %>
+  <%= render 'admin/header', website: '', campaigns: '', payments: 'active' %>
+
+    <ul class="nav nav-tabs">
+      <li><a href="<%= admin_processor_setup_path %>">Payment Processor</a></li>
+      <li class="active"><a href="<%= admin_bank_setup_path %>">Bank Setup</a></li>
+    </ul>
 
   <div id="admin_bank_setup">
 

--- a/app/views/admin/admin_processor_setup.html.erb
+++ b/app/views/admin/admin_processor_setup.html.erb
@@ -1,0 +1,53 @@
+<div id="admin">
+  <div class="container content_box clearfix">
+
+  <%= render 'admin/header', website: '', campaigns: '', payments: 'active' %>
+
+    <ul class="nav nav-tabs">
+      <li class="active"><a href="<%= admin_processor_setup_path %>">Payment Processor</a></li>
+      <li><a href="<%= admin_bank_setup_path %>">Bank Setup</a></li>
+    </ul>
+
+  <div id="admin_processor_setup">
+
+    <div class="main_content">
+
+      <% if @settings.payments_activated? %>
+
+      <h4>Your payment processor is all set up!</h4>
+      <p>Payments can now be activated for your campaigns.  Please make sure to set up your bank account information by clicking the tab above so that you may receive payouts!</p>
+
+      <% else %>
+
+      <%= form_tag(admin_processor_setup_path, method: "post", id: "admin_crowdtilt_form") %>
+
+      <fieldset>
+        <p>Crowdhoster is set up to use the Crowdtilt API for credit card transactions and bank payouts.  Please contact support.api@crowdtilt.com to request production Crowdtilt API credentials.</p>
+
+          <div class="form-row clearfix">
+            <div class="field">
+              <label for="ct_prod_api_key">Crowdtilt Production API Key</label>
+              <input name="ct_prod_api_key" id="ct_prod_api_key" type="text" style="width: 320px">
+            </div>
+          </div>
+          <div class="form-row clearfix">
+            <div class="field">
+              <label for="ct_prod_api_secret">Crowdtilt Production API Secret</label>
+              <input name="ct_prod_api_secret" id="ct_prod_api_secret" type="text" style="width: 320px">
+            </div>
+          </div>
+
+        </fieldset>
+
+        <button class="btn btn-primary show_loader" data-loader="bank_form" type="submit">Save</button>
+        <span class="loader" data-loader="bank_form" style="display:none"></span>
+      </form>
+      <div id="errors"></div>
+
+      <% end %>
+
+    </div>
+
+  </div>
+  </div>
+</div>

--- a/app/views/admin/admin_website.html.erb
+++ b/app/views/admin/admin_website.html.erb
@@ -1,7 +1,7 @@
 <div id="admin">
   <div class="container content_box clearfix">
 
-  <%= render 'admin/header', website: 'active', campaigns: '', bank: '' %>
+  <%= render 'admin/header', website: 'active', campaigns: '', payments: '' %>
 
   <div id="admin_website">
 

--- a/app/views/admin/campaigns/_form.html.erb
+++ b/app/views/admin/campaigns/_form.html.erb
@@ -320,8 +320,12 @@
     <div class="field clearfix">
       <% if !f.object.production_flag %>
         <p class="explanation">Campaigns remain in 'sandbox' mode until you choose to activate real payments. This lets you run test transactions on the campaign. WARNING: once you activate payments, you cannot go back to sandbox mode.</p>
-        <label>Activate payments?</label>
-        <%= f.check_box :production_flag %>
+        <% if @settings.payments_activated? %>
+          <label>Activate payments?</label>
+          <%= f.check_box :production_flag %>
+        <% else %>
+          You must set up your payment processor before activating payments. Visit "Payment Settings" from the admin menu to do this.
+        <% end %>
       <% else %>
         <p class="explanation">You have activated payments for this campaign, which means transactions WILL be processed. This cannot be undone for this campaign. If you activated payments by mistake, we recommend ending and un-publishing this campaign and creating a new one.</p>
         <label><i class="icon-ok"></i> Payments activated</label>

--- a/app/views/admin/campaigns/edit.html.erb
+++ b/app/views/admin/campaigns/edit.html.erb
@@ -1,7 +1,7 @@
 <div id="admin">
   <div class="container content_box clearfix">
 
-  <%= render 'admin/header', website: '', campaigns: 'active', bank: '' %>
+  <%= render 'admin/header', website: '', campaigns: 'active', payments: '' %>
 
   <div id="admin_campaigns">
     <%= render 'form' %>

--- a/app/views/admin/campaigns/index.html.erb
+++ b/app/views/admin/campaigns/index.html.erb
@@ -1,7 +1,7 @@
 <div id="admin">
   <div class="container content_box clearfix">
 
-  <%= render 'admin/header', website: '', campaigns: 'active', bank: '' %>
+  <%= render 'admin/header', website: '', campaigns: 'active', payments: '' %>
 
     <div id="admin_campaigns">
 

--- a/app/views/admin/campaigns/new.html.erb
+++ b/app/views/admin/campaigns/new.html.erb
@@ -1,7 +1,7 @@
 <div id="admin">
   <div class="container content_box clearfix">
 
-  <%= render 'admin/header', website: '', campaigns: 'active', bank: '' %>
+  <%= render 'admin/header', website: '', campaigns: 'active', payments: '' %>
 
   <div id="admin_campaigns">
     <%= render 'form' %>

--- a/app/views/admin/campaigns/payments.html.erb
+++ b/app/views/admin/campaigns/payments.html.erb
@@ -1,7 +1,7 @@
 <div id="admin">
   <div class="container content_box clearfix">
 
-  <%= render 'admin/header', website: '', campaigns: 'active', bank: '' %>
+  <%= render 'admin/header', website: '', campaigns: 'active', payments: '' %>
 
   <div id="admin_payments">
     <h4><%= @campaign.name %></h4>

--- a/app/views/campaigns/checkout_confirmation.html.erb
+++ b/app/views/campaigns/checkout_confirmation.html.erb
@@ -9,6 +9,9 @@
     </div>
     <div class="well confirmation_sidebar">
       <h4>Payment Summary</h4>
+      <% if !@campaign.production_flag %>
+        <div style="color: red; margin-bottom: 10px;">This campaign is in sandbox mode, your card will not actually be charged.</div>
+      <% end%>
       <p>
       <strong>Date:</strong><br/> <%= @payment.created_at.strftime("%m/%d/%Y") %> <br/><br/>
       <strong>Amount:</strong><br/> $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> <br/><br/>

--- a/app/views/campaigns/checkout_payment.html.erb
+++ b/app/views/campaigns/checkout_payment.html.erb
@@ -136,6 +136,9 @@
         </form>
         <div id="errors" style="display: none"></div>
 
+        <% if !@campaign.production_flag %>
+          <div style="color: red; margin-top: 10px;">This campaign is in sandbox mode, your card will not actually be charged.</div>
+        <% end%>
     </div>
 
   </div>

--- a/app/views/user_mailer/payment_confirmation.html.erb
+++ b/app/views/user_mailer/payment_confirmation.html.erb
@@ -7,6 +7,10 @@ This email is a confirmation of your $<%= number_with_precision(@payment.amount.
 
 <br/><br/>
 
+<% if !@campaign.production_flag %>
+  <div style="color: red">This campaign is in sandbox mode, your card will not actually be charged.</div><br/><br/>
+<% end%>
+
 <strong>Payment Details:</strong><br/>
 Name: <%= @payment.fullname %> <br/>
 Date: <%= @payment.created_at.strftime("%m/%d/%Y") %> <br/>

--- a/app/views/user_mailer/payment_confirmation.text.erb
+++ b/app/views/user_mailer/payment_confirmation.text.erb
@@ -4,6 +4,10 @@ Hi <%= @payment.fullname.split(' ')[0] %>,
 
 This email is a confirmation of your $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> payment to <%= @campaign.name %>. If you have any questions about this campaign, please contact <%= @settings.reply_to_email %>.
 
+<% if !@campaign.production_flag %>
+This campaign is in sandbox mode, your card will not actually be charged.
+<% end%>
+
 Payment Details:
 
 Name: <%= @payment.fullname %>

--- a/config/initializers/crowdtilt_api.rb
+++ b/config/initializers/crowdtilt_api.rb
@@ -6,9 +6,9 @@ module Crowdtilt
                    mode: 'sandbox'
   end
 
-  def self.production
-    self.configure api_key: Rails.configuration.crowdtilt_production_key,
-                      api_secret: Rails.configuration.crowdtilt_production_secret,
+  def self.production(settings)
+    self.configure api_key: settings.ct_prod_api_key,
+                      api_secret: settings.ct_prod_api_secret,
                       mode: 'production'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Crowdhoster::Application.routes.draw do
   end
   match '/admin/campaigns/:id/copy',           to: 'admin/campaigns#copy',                  as: :admin_campaigns_copy
   match '/admin/campaigns/:id/payments',       to: 'admin/campaigns#payments',              as: :admin_campaigns_payments
+  match '/admin/processor-setup',                   to: 'admin#admin_processor_setup',                as: :admin_processor_setup
   match '/admin/bank-setup',                   to: 'admin#admin_bank_setup',                as: :admin_bank_setup
   match '/ajax/verify',                        to: 'admin#ajax_verify',                     as: :ajax_verify
 

--- a/db/migrate/20130917210404_add_crowdtilt_prod_keys_to_settings.rb
+++ b/db/migrate/20130917210404_add_crowdtilt_prod_keys_to_settings.rb
@@ -1,0 +1,6 @@
+class AddCrowdtiltProdKeysToSettings < ActiveRecord::Migration
+  def change
+    add_column :settings, :ct_prod_api_key, :string
+    add_column :settings, :ct_prod_api_secret, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130910234120) do
+ActiveRecord::Schema.define(:version => 20130917210404) do
 
   create_table "campaigns", :force => true do |t|
     t.string   "name"
@@ -169,6 +169,8 @@ ActiveRecord::Schema.define(:version => 20130910234120) do
     t.string   "reply_to_email",              :default => "team@crowdhoster.com", :null => false
     t.text     "custom_js"
     t.string   "mailgun_route_id"
+    t.string   "ct_prod_api_key"
+    t.string   "ct_prod_api_secret"
   end
 
   create_table "users", :force => true do |t|

--- a/lib/tasks/sync_payments.rake
+++ b/lib/tasks/sync_payments.rake
@@ -9,7 +9,7 @@ namespace :ch do
     campaign = Campaign.find_by_ct_campaign_id(ENV['CAMPAIGN_ID'])
     if campaign
       puts "Synching payments for #{campaign.name} (#{ENV['CAMPAIGN_ID']})"
-      Rails.env.production? ? Crowdtilt.production : Crowdtilt.sandbox
+      campaign.production_flag ? Crowdtilt.production(Settings.find_by_id(1)) : Crowdtilt.sandbox
       begin
         response = Crowdtilt.get("campaigns/#{campaign.ct_campaign_id}/payments?page=1&per_page=100")
       rescue => exception


### PR DESCRIPTION
A big hurdle to developers getting Crowdhoster up and running was the need to get production Crowdtilt API keys before the app could even be initialized.  No longer!  Now the app will work completely with just a set of sandbox credentials provided in the .env file.  A new admin screen for setting up the production payment processor has been added, which for now just asks for a set of production Crowdtilt API keys.  Until the payment processor has been set up, campaigns cannot be promoted to production payments.

We've also made the warning messages that a campaign is in sandbox mode more prominent so no users will be confused!
