### PR TITLE
Fix #108 - Add data migration to import the Crowdtilt keys from .env

### DIFF
--- a/db/migrate/20130927230841_import_ct_keys_from_env.rb
+++ b/db/migrate/20130927230841_import_ct_keys_from_env.rb
@@ -1,0 +1,21 @@
+class ImportCtKeysFromEnv < ActiveRecord::Migration
+  def up
+    # Import CROWDTILT_PRODUCTION_KEY and CROWDTILT_PRODUCTION_SECRET from .env
+    say_with_time "Importing Crowdtilt keys from .env" do
+      Settings.reset_column_information
+
+      # If there is a settings object with guest and admin IDs, 
+      # the site was already initialized with the Crowdtilt API
+      if @settings = Settings.first
+        if @settings.ct_production_guest_id && @settings.ct_production_admin_id
+          @settings.update_attribute(:ct_prod_api_key, ENV['CROWDTILT_PRODUCTION_KEY'])
+          @settings.update_attribute(:ct_prod_api_secret, ENV['CROWDTILT_PRODUCTION_SECRET'])
+        end
+      end
+
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130917210404) do
+ActiveRecord::Schema.define(:version => 20130927230841) do
 
   create_table "campaigns", :force => true do |t|
     t.string   "name"


### PR DESCRIPTION
Fixes #108 - Looks like the above view exception is resolved with a database migration, but the underlying editing of bank information is still broken. 

I added a data migration to import the Crowdtilt production keys from the .env file if there's already a settings object with the necessary attributes (indicating that the site has already been initialized for payments with Crowdtilt)
