### PR TITLE
Add target attributes to prevent losing unsaved content when enabling comment functionality

### DIFF
--- a/app/views/admin/campaigns/_form.html.erb
+++ b/app/views/admin/campaigns/_form.html.erb
@@ -241,10 +241,10 @@
   <legend>Comments (optional)</legend>
     <div class="field clearfix">
       <label>Include a user comment section?</label>
-      <p class="explanation">Add a comment section where backers can discuss your campaign. You will need a free moderator account from <a href="https://disqus.com/admin/signup/">Disqus.</a></p>
+      <p class="explanation">Add a comment section where backers can discuss your campaign. You will need a free moderator account from <a href="https://disqus.com/admin/signup/" target="_blank">Disqus.</a></p>
       <%= f.check_box :include_comments %>
       <div class="include_comments_input" style="<%= @campaign.include_comments ? "" : "display:none" %>">
-        <label>Enter your Disqus Site Shortname (<a href="https://disqus.com/admin/signup/">Need one?</a>)</label>
+        <label>Enter your Disqus Site Shortname (<a href="https://disqus.com/admin/signup/" target="_blank">Need one?</a>)</label>
         <%= f.text_field :comments_shortname %>
       </div>
     </div>


### PR DESCRIPTION
Fixes an issue where some users would lose unsaved content by accidentally navigating away from the /campaign/edit form to request a Disqus Site ID to enable the comment section.
