### PR TITLE
Add "new campaign" shortcut

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -9,11 +9,17 @@
            <li>
              <a href="<%= url_for admin_website_path %>"><i class="icon-edit icon-white"></i> Edit homepage</a>
            </li>
+           <li>
+              <a href="<%= url_for new_admin_campaign_path %>"><i class="icon-plus icon-white"></i> New Campaign</a>
+           </li>
          <% end %>
 
          <% if request.fullpath.include? 'admin' %>
            <li>
              <a href="<%= url_for root_path %>"><i class="icon-chevron-left icon-white"></i> Back to website</a>
+           </li>
+           <li>
+              <a href="<%= url_for new_admin_campaign_path %>"><i class="icon-plus icon-white"></i> New Campaign</a>
            </li>
          <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,9 +19,9 @@ Crowdhoster::Application.routes.draw do
 
   match '/admin/campaigns/:id/copy',           to: 'admin/campaigns#copy',                  as: :admin_campaigns_copy
   match '/admin/campaigns/:id/payments',       to: 'admin/campaigns#payments',              as: :admin_campaigns_payments
-  match '/admin/processor-setup',                   to: 'admin#admin_processor_setup',                as: :admin_processor_setup
+  match '/admin/processor-setup',              to: 'admin#admin_processor_setup',           as: :admin_processor_setup
   match '/admin/bank-setup',                   to: 'admin#admin_bank_setup',                as: :admin_bank_setup
-  match '/admin/notification-setup',           to: 'admin#admin_notification_setup',                as: :admin_notification_setup
+  match '/admin/notification-setup',           to: 'admin#admin_notification_setup',        as: :admin_notification_setup
   match '/ajax/verify',                        to: 'admin#ajax_verify',                     as: :ajax_verify
 
   # CAMPAIGNS


### PR DESCRIPTION
An attempt to make it easier to start a new campaign from a fresh initialization of the app, this adds a shortcut to "new campaign" in the admin navbar partial.

![screen shot 2013-11-18 at 5 09 37 pm](https://f.cloud.github.com/assets/1132438/1568771/48b0ffd8-50b7-11e3-9e75-d6a238253f80.png)

This PR also includes cleanup of formatting in routes.rb, but introduces no functional changes to the file.
