### PR TITLE
Updated ordering of status text in website campaign boxes

### DIFF
--- a/app/views/theme/views/homepage.html.erb
+++ b/app/views/theme/views/homepage.html.erb
@@ -47,6 +47,16 @@
             <% end %>
 
             <p class="numbers pull-left">
+              <% if campaign.goal_type == 'dollars' %>
+              <strong>$<%= campaign.raised_amount.ceil %></strong><br/>
+              <%= campaign.progress_text %>
+              <% else %>
+               <strong><%= campaign.orders %></strong><br/>
+              <%= campaign.contributor_reference.pluralize(campaign.orders) %>
+              <% end %>
+            </p>
+
+            <p class="numbers pull-right" style="text-align:right">
             <% if campaign.expired? %>
               <strong>No</strong><br/>days left!
             <% else %>
@@ -55,16 +65,6 @@
                 <%= distance_of_time_in_words_to_now(campaign.expiration_date).gsub(/\d/, "").gsub("about", "") %> left
               </span>
             <% end %>
-            </p>
-
-            <p class="numbers pull-right" style="text-align:right">
-              <% if campaign.goal_type == 'dollars' %>
-              <strong>$<%= campaign.raised_amount.ceil %></strong><br/>
-              <%= campaign.progress_text %>
-              <% else %>
-               <strong><%= campaign.orders %></strong><br/>
-              <%= campaign.contributor_reference.pluralize(campaign.orders) %>
-              <% end %>
             </p>
 
           </a>


### PR DESCRIPTION
An aesthetic change that swaps the "funded progress" and "time remaining" for campaigns displayed on the homepage.

Old:
![screen shot 2013-11-18 at 6 01 53 pm](https://f.cloud.github.com/assets/1132438/1569160/f1cd23f6-50be-11e3-8450-d8f36b2346a2.png)
New:
![screen shot 2013-11-18 at 6 06 14 pm](https://f.cloud.github.com/assets/1132438/1569172/31bbf334-50bf-11e3-889b-955682745835.png)
