### PR TITLE
Removed requirement for additional info on checkout payment page

### DIFF
--- a/app/assets/javascripts/validate.js
+++ b/app/assets/javascripts/validate.js
@@ -234,7 +234,6 @@ $( document ).ready(function() {
     rules: {
       fullname: { required: true },
       email: { required: true, email: true },
-      additional_info: { required: true },
       address_one: { required: true },
       city: { required: true },
       state: { required: true },
@@ -252,9 +251,6 @@ $( document ).ready(function() {
       email: {
         required: "Please enter your email address.",
         email: "Hmm. That doesn't look like a valid email."
-      },
-      additional_info: {
-        required: "We need this additional information to complete your contribution."
       },
       address_one: {
         required: "We need your street address"


### PR DESCRIPTION
Since the need to collect additional information is often conditional to a specific reward (eg: "Select which color T-shirt you would like"), this removes the global validation rule for this field on the checkout_payment page.
