### PR TITLE
Fix duplicate form submission from payments confirmation page

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -59,7 +59,7 @@ class CampaignsController < ApplicationController
 
   end
 
-  def checkout_confirmation
+  def checkout_process
 
     ct_user_id = params[:ct_user_id]
     ct_card_id = params[:ct_card_id]
@@ -170,6 +170,17 @@ class CampaignsController < ApplicationController
       logger.info "ERROR WITH EMAIL RECEIPT: #{exception.message}"
     end
 
+    redirect_to checkout_confirmation_url(@campaign), :status => 303, :flash => { payment_guid: @payment.ct_payment_id }
+
+  end
+
+  def checkout_confirmation
+    @payment = Payment.where(:ct_payment_id => flash[:payment_guid]).first
+    flash[:payment_guid] = nil # Unset flash because application renders all flash vars (long-term should be refactored)
+
+    if !@payment
+      redirect_to campaign_home_url(@campaign)
+    end
   end
 
   private

--- a/app/views/campaigns/checkout_payment.html.erb
+++ b/app/views/campaigns/checkout_payment.html.erb
@@ -5,7 +5,7 @@
 
     <div class="well checkout_block" style="padding-bottom: 16px">
 
-        <form accept-charset="UTF-8" action="<%= checkout_confirmation_path(@campaign) %>" method="post" id="payment_form">
+        <form accept-charset="UTF-8" action="<%= checkout_process_path(@campaign) %>" method="post" id="payment_form">
 
           <input name="authenticity_token" type="hidden" value="<%= form_authenticity_token %>">
           <h4 class="contact">Contact Information</h4>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Crowdhoster::Application.routes.draw do
   # CAMPAIGNS
   match '/:id/checkout/amount',                to: 'campaigns#checkout_amount',             as: :checkout_amount
   match '/:id/checkout/payment',               to: 'campaigns#checkout_payment',            as: :checkout_payment
+  match '/:id/checkout/process',               to: 'campaigns#checkout_process',            as: :checkout_process
   match '/:id/checkout/confirmation',          to: 'campaigns#checkout_confirmation',       as: :checkout_confirmation
   match '/:id',                                to: 'campaigns#home',                        as: :campaign_home
 


### PR DESCRIPTION
Implements PRG pattern on payments flow to prevent duplicate payments from form resubmission on confirmation page. 

This PR does not fix the resubmission issue if a user refreshes before the confirmation page loads. 
