### PR TITLE
Add ability for campaign admin to enter a contact phone number

### DIFF
--- a/app/assets/javascripts/validate.js
+++ b/app/assets/javascripts/validate.js
@@ -23,6 +23,7 @@ $( document ).ready(function() {
     rules: {
       "settings[site_name]": { required: true },
       "settings[reply_to_email]": { required: true, email: true },
+      "settings[phone_number]": { phoneUS: true },
       "settings[header_link_url]": { url: true },
       "settings[tweet_text]": { maxlength: 120 },
       "settings[facebook_app_id]": { digits: true },
@@ -33,6 +34,9 @@ $( document ).ready(function() {
       "settings[reply_to_email]": {
         required: "Please enter a reply to email address",
         email: "Hmm. That doesn't look like a valid email"
+      },
+      "settings[phone_number]": {
+        phoneUS: "Hmm. That doesn't look like a valid phone number. <br> ex: 555-555-5555"
       },
       "settings[header_link_url]": {
         url: "Hmm. That doesn't look like a valid URL. ex: http://crowdtilt.com"

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -3,7 +3,7 @@ class Settings < ActiveRecord::Base
                   :logo_image, :logo_image_delete, :copyright_text, :facebook_title,
                   :facebook_description, :facebook_image, :facebook_image_delete, :homepage_content,
                   :custom_css, :header_link_text, :header_link_url, :ct_sandbox_guest_id, :ct_production_guest_id,
-                  :ct_sandbox_admin_id, :ct_production_admin_id, :reply_to_email, :custom_js, :default_campaign_id, :indexable
+                  :ct_sandbox_admin_id, :ct_production_admin_id, :reply_to_email, :custom_js, :default_campaign_id, :indexable, :phone_number
 
   attr_accessor :logo_image_delete, :facebook_image_delete
 

--- a/app/views/admin/admin_website.html.erb
+++ b/app/views/admin/admin_website.html.erb
@@ -21,6 +21,11 @@
           <label>Reply To Email</label>
           <%= f.text_field :reply_to_email %>
         </div>
+        <div class="field clearfix">
+          <p class="explanation">Enter a phone number where contributors can reach you.</p>
+          <label>Contact Phone Number (Optional)</label>
+          <%= f.text_field :phone_number %>
+        </div>
 
         <div class="field clearfix">
           <p class="explanation">If you would like to display a logo instead of your site name in the header, upload it here. Resize the image before uploading for best results in your template.</p>

--- a/app/views/user_mailer/payment_confirmation.html.erb
+++ b/app/views/user_mailer/payment_confirmation.html.erb
@@ -3,7 +3,7 @@ Hi <%= @payment.fullname.split(' ')[0] %>,
 
 <br/><br/>
 
-This email is a confirmation of your $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> payment to <%= @campaign.name %>. If you have any questions about this campaign, please contact <%= @settings.reply_to_email %>.
+This is an email receipt for your $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> contribution to <a href="<%= url_for campaign_home_url(@campaign) %>"><%= @campaign.name %></a>. If you have any questions about this campaign, please contact the campaign's organizer at <%= @settings.reply_to_email %><% if @settings.phone_number.present? %> or <%= @settings.phone_number %><% end %>.
 
 <br/><br/>
 

--- a/app/views/user_mailer/payment_confirmation.text.erb
+++ b/app/views/user_mailer/payment_confirmation.text.erb
@@ -2,7 +2,7 @@
 
 Hi <%= @payment.fullname.split(' ')[0] %>,
 
-This email is a confirmation of your $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> payment to <%= @campaign.name %>. If you have any questions about this campaign, please contact <%= @settings.reply_to_email %>.
+This is an email receipt for your $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> contribution to <%= @campaign.name %> (<%= url_for campaign_home_url(@campaign) %>). If you have any questions about this campaign, please contact the campaign's organizer at <%= @settings.reply_to_email %><% if @settings.phone_number.present? %> or <%= @settings.phone_number %><% end %>.
 
 <% if !@campaign.production_flag %>
 This campaign is in sandbox mode, your card will not actually be charged.

--- a/db/migrate/20131128003747_add_phone_number_to_settings.rb
+++ b/db/migrate/20131128003747_add_phone_number_to_settings.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToSettings < ActiveRecord::Migration
+  def change
+    add_column :settings, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131007231616) do
+ActiveRecord::Schema.define(:version => 20131128003747) do
 
   create_table "campaigns", :force => true do |t|
     t.string   "name"
@@ -171,8 +171,9 @@ ActiveRecord::Schema.define(:version => 20131007231616) do
     t.string   "mailgun_route_id"
     t.string   "ct_prod_api_key"
     t.string   "ct_prod_api_secret"
-    t.integer  "default_campaign_id"
     t.boolean  "indexable",                   :default => true
+    t.integer  "default_campaign_id"
+    t.string   "phone_number"
   end
 
   create_table "users", :force => true do |t|


### PR DESCRIPTION
This adds the option for a campaign creator to share their phone number with backers.

If a phone number is provided, it is displayed in the confirmation email receipt as shown below:

![screen shot 2013-11-27 at 4 58 46 pm](https://f.cloud.github.com/assets/1132438/1636275/475ce6e8-57c8-11e3-8313-68db66177204.png)
