### PR TITLE
Ensure Facebook like button appears regardless of input of Facebook app ID

### DIFF
--- a/app/views/admin/admin_website.html.erb
+++ b/app/views/admin/admin_website.html.erb
@@ -66,12 +66,6 @@
         </div>
 
         <div class="field clearfix">
-          <p class="explanation">Include your Facebook app ID here to set up your social sharing buttons. Visit https://developers.facebook.com/apps to create an app for your site. The like button will NOT show up unless you provide this ID.</p>
-          <label>Facebook App ID</label>
-          <%= f.text_field :facebook_app_id %>
-        </div>
-
-        <div class="field clearfix">
           <p class="explanation">The title shown when your site is shared via Facebook. Leave this blank if you want to use your project name.</p>
           <label>Facebook Title</label>
           <%= f.text_field :facebook_title %>
@@ -128,6 +122,11 @@
             <p class="explanation">Uncheck this box if you would like all campaigns to be private and not appear on search engines like Google.</p>
             <label>Allow search engines to index your Crowdhoster site</label>
             <%= f.check_box :indexable %>
+          </div>
+          <div class="field clearfix">
+            <p class="explanation">If you're using a custom domain (eg: campaigns.YourSite.com), you'll need to include a custom Facebook app ID here. Visit https://developers.facebook.com/apps to create a free app for your site.</p>
+            <label>Custom Facebook App ID</label>
+            <%= f.text_field :facebook_app_id %>
           </div>
           <div class="field clearfix">
             <p class="explanation">Add your own CSS styles to fully customize the look and feel of your site.</p>

--- a/app/views/layouts/_facebook_metas.html.erb
+++ b/app/views/layouts/_facebook_metas.html.erb
@@ -1,8 +1,6 @@
 <meta property='og:type' content="website" />
 <meta property='og:site_name' content="<%= @settings.facebook_title.blank? ? @settings.site_name : @settings.facebook_title %>" />
-<% if !@settings.facebook_app_id.blank? %>
-  <meta property='fb:app_id' content="<%= @settings.facebook_app_id %>" />
-<% end %>
+<meta property='fb:app_id' content="<%= @settings.facebook_app_id.present? ? @settings.facebook_app_id : 331145500360318 %>" />
 
 <% params[:controller] == 'campaigns' ? c = @campaign : c = false %>
 

--- a/app/views/layouts/_social_js.html.erb
+++ b/app/views/layouts/_social_js.html.erb
@@ -1,9 +1,8 @@
-<% if !@settings.facebook_app_id.blank? %>
 <div id="fb-root"></div>
 <script>
   window.fbAsyncInit = function() {
     FB.init({
-      appId      : '<%= @settings.facebook_app_id %>',
+      appId      : '<%= @settings.facebook_app_id.present? ? @settings.facebook_app_id : 331145500360318 %>',
       status     : true,
       xfbml      : true
     });
@@ -18,7 +17,6 @@
      fjs.parentNode.insertBefore(js, fjs);
    }(document, 'script', 'facebook-jssdk'));
 </script>
-<% end %>
 
 <script>
 !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");


### PR DESCRIPTION
Previously, if the campaign admin did not create and enter a Facebook app ID, their like button would not appear. This fixes that issue by creating a default app id. Since inputting a custom Facebook app ID is still desired by some, it is still an option and available under "advanced settings."

This addresses issue #127. 
