### PR TITLE
Added ability to update bank account

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,7 +2,7 @@ class AdminController < ApplicationController
   layout "admin"
   before_filter :authenticate_user!
   before_filter :verify_admin
-  before_filter :set_ct_env, only: [:admin_bank_setup, :ajax_verify]
+  before_filter :set_ct_env, only: [:admin_bank_account, :create_admin_bank_account, :delete_admin_bank_account, :ajax_verify]
 
   def admin_website
     #Handle the form submission if request is PUT
@@ -30,28 +30,33 @@ class AdminController < ApplicationController
     end
   end
 
-  def admin_bank_setup
-    redirect_to admin_processor_setup_url, flash: { error: "Please set up your payment processor before providing your bank details" } and return unless @settings.payments_activated?
+  def create_admin_bank_account
+    if params[:ct_bank_id].blank?
+      flash = { :error => "Looks like you have JavaScript disabled. JavaScript is required for bank account setup." }
+    else
+      begin
+        bank = {
+          id: params[:ct_bank_id]
+        }
+        Crowdtilt.post('/users/' + @ct_admin_id + '/banks/default', {bank: bank})
+      rescue => exception
+        flash = { :error => "An error occurred, please contact team@crowdhoster.com: #{exception.message}" }
+      else
+        flash = { :success => "Your bank account is all set up!" }
+      end
+    end
+    redirect_to admin_bank_account_url, :status => 303, :flash => flash
+  end
+
+  def admin_bank_account
+    unless @settings.payments_activated?
+      redirect_to admin_processor_setup_url, flash: { error: "Please set up your payment processor before providing your bank details" } and return
+    end
     @bank = {}
     begin
       response = Crowdtilt.get('/users/' + @ct_admin_id + '/banks/default')
     rescue => exception # response threw an error, default bank may not be set up
-      if request.post?
-        if params[:ct_bank_id].blank?
-          flash.now[:error] = "An error occurred, please try again" and return
-        else
-          begin
-            bank = {
-              id: params[:ct_bank_id]
-            }
-            response = Crowdtilt.post('/users/' + @ct_admin_id + '/banks/default', {bank: bank})
-          rescue => exception
-            flash.now[:error] = exception.message and return
-          else
-            @bank = response['bank']
-          end
-        end
-      end
+      # do nothing
     else # response is good, check for default bank
       if response['bank'] # default bank is already set up
         @bank = response['bank']
@@ -59,6 +64,23 @@ class AdminController < ApplicationController
         flash.now[:error] = "An error occurred, please contact team@crowdhoster.com" # this should never happen
       end
     end
+  end
+
+  def delete_admin_bank_account
+    begin
+      response = Crowdtilt.get('/users/' + @ct_admin_id + '/banks/default')
+    rescue => exception
+        flash = { :error => "No default bank account" }
+    else
+      begin
+        Crowdtilt.delete('/users/' + @ct_admin_id + '/banks/' + response['bank']['id'])
+      rescue => exception
+        flash = { :error => "An error occurred, please contact team@crowdhoster.com: #{exception.message}" }
+      else
+        flash = { :info => "Bank account deleted successfully" }
+      end
+    end
+    redirect_to admin_bank_account_url, :status => 303, :flash => flash
   end
 
   def ajax_verify

--- a/app/views/admin/admin_bank_account.html.erb
+++ b/app/views/admin/admin_bank_account.html.erb
@@ -5,7 +5,7 @@
 
     <ul class="nav nav-tabs nav-bank-setup">
       <li><a href="<%= admin_processor_setup_path %>">Payment Processor</a></li>
-      <li class="active"><a href="<%= admin_bank_setup_path %>">Bank Setup</a></li>
+      <li class="active"><a href="<%= admin_bank_account_path %>">Bank Setup</a></li>
     </ul>
 
   <div id="admin_bank_setup">
@@ -21,12 +21,12 @@
       </div>
       <div class="more_info">
         <p>Campaign funds are transferred automatically to your account within 2 business days of campaign expiration. </p>
-        <p>Need to change your bank account? <a href="mailto:team@crowdhoster.com?subject=Please reset my bank account info&body=Hi! I'd like to change my bank account. Please reset it for the Crowdhoster site named:">Send us an email</a>.</p>
+        <p>Need to change your bank account? <%= link_to 'Delete bank account', delete_admin_bank_account_path, :confirm => 'Are you sure you want to delete this bank account?', :method => :delete %></p>
       </div>
 
       <% else %>
 
-      <%= form_tag(admin_bank_setup_path, method: "post", id: "admin_bank_form") %>
+      <%= form_tag(create_admin_bank_account_path, method: "post", id: "admin_bank_form") %>
 
       <h4>Personal Information <span class="label show_tooltip" data-placement="right" data-title="BUSINESS ACCOUNTS: <br>To prevent fraud, we verify your personal identity independently of your business bank account. <br> DO NOT ENTER YOUR BUSINESS ADDRESS / PHONE. Please enter your personal details here and your business account routing and account numbers in the 'Banking Information' section below.">Using a business account?</span></h4>
       <fieldset>

--- a/app/views/admin/admin_processor_setup.html.erb
+++ b/app/views/admin/admin_processor_setup.html.erb
@@ -5,7 +5,7 @@
 
     <ul class="nav nav-tabs nav-processor-setup">
       <li class="active"><a href="<%= admin_processor_setup_path %>">Payment Processor</a></li>
-      <li><a href="<%= admin_bank_setup_path %>">Bank Setup</a></li>
+      <li><a href="<%= admin_bank_account_path %>">Bank Setup</a></li>
     </ul>
 
   <div id="admin_processor_setup">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,9 @@ Crowdhoster::Application.routes.draw do
   match '/admin/campaigns/:id/copy',           to: 'admin/campaigns#copy',                  as: :admin_campaigns_copy
   match '/admin/campaigns/:id/payments',       to: 'admin/campaigns#payments',              as: :admin_campaigns_payments
   match '/admin/processor-setup',              to: 'admin#admin_processor_setup',           as: :admin_processor_setup
-  match '/admin/bank-setup',                   to: 'admin#admin_bank_setup',                as: :admin_bank_setup
+  post '/admin/bank-setup',                    to: 'admin#create_admin_bank_account',       as: :create_admin_bank_account
+  get '/admin/bank-setup',                     to: 'admin#admin_bank_account',              as: :admin_bank_account
+  delete '/admin/bank-setup',                  to: 'admin#delete_admin_bank_account',       as: :delete_admin_bank_account
   match '/admin/notification-setup',           to: 'admin#admin_notification_setup',        as: :admin_notification_setup
   match '/ajax/verify',                        to: 'admin#ajax_verify',                     as: :ajax_verify
 


### PR DESCRIPTION
Previously, Admins were unable to change their bank account without emailing Crowdtilt API support. This PR introduces the ability for admins to update their bank account.

Addresses issue #23 
