### PR TITLE
Added clarification for Disqus comment setup

### DIFF
--- a/app/views/admin/campaigns/_form.html.erb
+++ b/app/views/admin/campaigns/_form.html.erb
@@ -257,7 +257,10 @@
       <%= f.check_box :include_comments %>
       <div class="include_comments_input" style="<%= @campaign.include_comments ? "" : "display:none" %>">
         <label>Enter your Disqus Site Shortname (<a href="https://disqus.com/admin/signup/" target="_blank">Need one?</a>)</label>
-        <%= f.text_field :comments_shortname %>
+        <div class="input-append">
+          <%= f.text_field :comments_shortname, :placeholder => 'shortname' %>
+          <span class="add-on">.disqus.com</span>
+        </div>
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
Updating the input field for the Disqus shortname to more closely match the Disqus registration page linked to in the helper text (http://disqus.com/admin/create/).
### Crowdhoster

![screen shot 2014-01-03 at 10 19 18 am](https://f.cloud.github.com/assets/1132438/1841366/9f5f5054-74a3-11e3-952e-3341c3169fe8.png)
### Disqus

![screen shot 2014-01-03 at 10 21 35 am](https://f.cloud.github.com/assets/1132438/1841374/e618c052-74a3-11e3-877f-8eca30c143b4.png)
