### PR TITLE
Allow reward image url to be blank

### DIFF
--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -2,7 +2,7 @@ class Reward < ActiveRecord::Base
   attr_accessible :title, :description, :delivery_date, :number, :price, :campaign_id, :visible_flag, :image_url
 
    validates :title, :description, :delivery_date, :price, presence: true
-   validates :image_url, :format => URI::regexp(%w(http https))
+   validates :image_url, :format => URI::regexp(%w(http https)), :allow_blank => true
 
   belongs_to :campaign
   has_many :payments


### PR DESCRIPTION
Fixed a bug where reward image url could not be blank when creating / updating a campaign reward.
