### PR TITLE
Refactor model error message display

### DIFF
--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -58,11 +58,7 @@ class Admin::CampaignsController < ApplicationController
 
     # Check if the new settings pass validations...if not, re-render form and display errors in flash msg
     if !@campaign.valid?
-      message = ''
-      @campaign.errors.each do |key, error|
-        message = message + key.to_s.humanize + ' ' + error.to_s + ', '
-      end
-      flash.now[:error] = message[0...-2]
+      flash.now[:error] = @campaign.errors.full_messages.join(', ')
       render action: "new"
       return
     end
@@ -119,11 +115,7 @@ class Admin::CampaignsController < ApplicationController
 
       # Check again for campaign validity now that we've added faqs and rewards
       if !@campaign.valid?
-        message = ''
-        @campaign.errors.each do |key, error|
-          message = message + key.to_s.humanize + ' ' + error.to_s + ', '
-        end
-        flash.now[:error] = message[0...-2]
+        flash.now[:error] = @campaign.errors.full_messages.join(', ')
         render action: "new"
         return
       end
@@ -206,11 +198,7 @@ class Admin::CampaignsController < ApplicationController
 
     # Check if the new settings pass validations...if not, re-render form and display errors in flash msg
     if !@campaign.valid?
-      message = ''
-      @campaign.errors.each do |key, error|
-        message = message + key.to_s.humanize + ' ' + error.to_s + ', '
-      end
-      flash.now[:error] = message[0...-2]
+      flash.now[:error] = @campaign.errors.full_messages.join(', ')
       render action: "edit"
       return
     end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,11 +10,7 @@ class AdminController < ApplicationController
       if @settings.update_attributes(params[:settings])
         flash.now[:success] = "Website settings successfully updated!"
       else
-        message = ''
-        @settings.errors.each do |key, error|
-          message = message + key.to_s.humanize + ' ' + error.to_s + ', '
-        end
-        flash.now[:error] = message[0...-2]
+        flash.now[:error] = @settings.errors.full_messages.join(', ')
       end
     end
   end

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -120,11 +120,8 @@ class CampaignsController < ApplicationController
      @payment = @campaign.payments.new(payment_params)
 
     if !@payment.valid?
-      message = ''
-      @payment.errors.each do |key, error|
-        message = message + key.to_s.humanize + ' ' + error.to_s + ', '
-      end
-      redirect_to checkout_amount_url(@campaign), flash: { error: message[0...-2] } and return
+      error_messages = @payment.errors.full_messages.join(', ')
+      redirect_to checkout_amount_url(@campaign), flash: { error: error_messages } and return
     end
 
     # Check if there's an existing payment with the same payment_params and client_timestamp. 


### PR DESCRIPTION
Use the built-in full_message method on ActiveModel::Errors instead of manually combining
