### PR TITLE
Add example usage of Crowdhoster API usage

### DIFF
--- a/app/views/admin/campaigns/_form.html.erb
+++ b/app/views/admin/campaigns/_form.html.erb
@@ -364,6 +364,10 @@
         <p><%= api_campaign_url(id: @campaign.id)%></p>
         <label>API key</label>
         <p><%= @settings.api_key %></p>
+        <label>Example Usage (Return a JSON array of campaign data)</label>
+        <p><%= api_campaign_url(id: @campaign.id)%>?api_key=<%= @settings.api_key %></p>
+        <label>Example Usage (Return a JSON array of all payments)</label>
+        <p><%= api_campaign_url(id: @campaign.id)%>/payments?api_key=<%= @settings.api_key %></p>
       </div>
      </div>
   </fieldset>


### PR DESCRIPTION
This adds some simple example requests for using the Crowdhoster API to return campaign data and payments.

![screen shot 2014-01-10 at 2 19 53 pm](https://f.cloud.github.com/assets/1132438/1891877/5b030fc0-7a45-11e3-9aae-e174ca7dba9e.png)
