### PR TITLE
Disable ability to click on rewards if the campaign is expired.

### DIFF
--- a/app/views/theme/views/campaign.html.erb
+++ b/app/views/theme/views/campaign.html.erb
@@ -159,7 +159,7 @@
             <% @campaign.rewards.order("price ASC").each do |reward| %>
             <% if reward.visible? %>
               <li id="rewards_click">
-                <a href="<%= url_for(checkout_amount_path(@campaign, reward: reward.id)) %>"  onclick="<%= 'return false' if reward.sold_out? %>" class="<%= 'disabled' if reward.sold_out? %>">
+                <a href="<%= url_for(checkout_amount_path(@campaign, reward: reward.id)) %>"  onclick="<%= 'return false' if reward.sold_out? || @campaign.expired? %>" class="<%= 'disabled' if reward.sold_out? || @campaign.expired? %>">
                   <p class="price">$<%= number_with_precision(reward.price, precision: (reward.price*100%100==0.0 ? 0 : 2)) %></p>
                   <p class="title"><%= reward.title %></p>
                   <% if reward.image_url.present? %><p class="image"><img src="<%= reward.image_url %>"></p><% end %>


### PR DESCRIPTION
This adds a disabled state to rewards if the campaign is expired.
