### PR TITLE
Added ability to duplicate expired campaigns

### DIFF
--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -14,6 +14,7 @@ class Admin::CampaignsController < ApplicationController
   def copy
     old_campaign = Campaign.find(params[:id])
     @campaign = old_campaign.dup
+    @campaign.expiration_date = Time.now + 30.days
     @campaign.published_flag = false
     @campaign.production_flag = false
 


### PR DESCRIPTION
Previously, an error was thrown when attempting to duplicate an expired campaign due to the expiration date being in the past.
