### PR TITLE
Comma delimit reward prices at the thousand level

### DIFF
--- a/app/assets/javascripts/campaigns.js.coffee
+++ b/app/assets/javascripts/campaigns.js.coffee
@@ -18,7 +18,7 @@ Crowdhoster.campaigns =
       $amount = $('#amount')
       new_amount = parseFloat($amount.attr('data-original')) * quantity
       $amount.val(new_amount)
-      $('#total').html(new_amount.toFixed(2))
+      $('#total').html(new_amount.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");)
 
     $('#amount').on "keyup", (e) ->
       $(this).addClass('edited')

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -27,6 +27,7 @@ class CampaignsController < ApplicationController
 
   def checkout_payment
     @reward = false
+    params[:amount].sub!(',', '') if params[:amount].present?
     if @campaign.payment_type == "fixed"
       if params.has_key?(:quantity)
         @quantity = params[:quantity].to_i

--- a/app/helpers/campaigns_helper.rb
+++ b/app/helpers/campaigns_helper.rb
@@ -1,6 +1,7 @@
 module CampaignsHelper
 
-  def short_price(price)
-    number_with_precision(price, precision: (price*100%100==0.0 ? 0 : 2))
+  def short_price(price, currency_symbol='', precision=nil)
+    precision ||= (price*100%100==0.0 ? 0 : 2)
+    "#{currency_symbol}#{number_with_precision(price, delimiter: ",", precision: precision)}"
   end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -2,6 +2,8 @@ class AdminMailer < ActionMailer::Base
   layout 'default_mailer'
   default from: "payments@crowdhoster.com"
 
+  helper :campaigns
+
   def payment_notification(payment_id)
     recipients = User
       .where(admin: true, wants_admin_payment_notification: true)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,8 @@
 class UserMailer < ActionMailer::Base
   layout 'default_mailer'
 
+  helper :campaigns
+
   def payment_confirmation(payment, campaign)
     @settings = Settings.first
     @payment = payment

--- a/app/views/admin/campaigns/index.html.erb
+++ b/app/views/admin/campaigns/index.html.erb
@@ -25,14 +25,14 @@
 
           <td>
             <% if campaign.goal_type == "dollars" %>
-              $<%= number_with_precision(campaign.goal_dollars.to_f, precision: 2) %>
+              <%= short_price(campaign.goal_dollars.to_f, '$', 2) %>
             <% else %>
               <%= campaign.goal_orders %>
             <% end %>
           </td>
           <td>
             <% if campaign.goal_type == "dollars" %>
-              $<%= number_with_precision(campaign.stats_raised_amount.to_f, precision: 2) %>
+              <%= short_price(campaign.stats_raised_amount.to_f, '$', 2) %>
             <% else %>
               <%= campaign.orders %>
             <% end %>

--- a/app/views/admin/campaigns/payments.html.erb
+++ b/app/views/admin/campaigns/payments.html.erb
@@ -62,8 +62,8 @@
             <% if @campaign.goal_type == 'orders' %>
             <td><%= payment.quantity %></td>
             <% end %>
-            <td class="amount">$<%= number_with_precision(payment.amount.to_f/100.0, precision: 2) %></td>
-            <td class="user_fee_amount">$<%= number_with_precision(payment.user_fee_amount.to_f/100.0, precision: 2) %></td>
+            <td class="amount"><%= short_price(payment.amount.to_f/100.0, '$', 2) %></td>
+            <td class="user_fee_amount"><%= short_price(payment.user_fee_amount.to_f/100.0, '$', 2) %></td>
             <td><%= payment.created_at.strftime("%m/%d/%Y") %></td>
             <td class="status"><%= payment.status %></td>
             <td class="ct_payment_id"><%= payment.ct_payment_id %></td>

--- a/app/views/admin_mailer/payment_notification.html.erb
+++ b/app/views/admin_mailer/payment_notification.html.erb
@@ -1,3 +1,3 @@
 <p><%= @payment.fullname %> just backed "<%= @payment.campaign.name %>".</p>
-<p>They contributed $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %><% if @reward %> and selected the "<%= @reward.title %>" <%= @campaign.reward_reference %><% end %>!</p>
+<p>They contributed <%= short_price(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, '$', 2) %><% if @reward %> and selected the "<%= @reward.title %>" <%= @campaign.reward_reference %><% end %>!</p>
 <p>Reach out and thank them by email: <%= @payment.email %>.</p>

--- a/app/views/admin_mailer/payment_notification.text.erb
+++ b/app/views/admin_mailer/payment_notification.text.erb
@@ -1,3 +1,3 @@
 <%= @payment.fullname %> just backed "<%= @payment.campaign.name %>".
-They contributed $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %><% if @reward %> and selected the "<%= @reward.title %>" <%= @campaign.reward_reference %><% end %>!
+They contributed <%= short_price(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, '$', 2) %><% if @reward %> and selected the "<%= @reward.title %>" <%= @campaign.reward_reference %><% end %>!
 Reach out and thank them by email: <%= @payment.email %>.

--- a/app/views/campaigns/checkout_amount.html.erb
+++ b/app/views/campaigns/checkout_amount.html.erb
@@ -12,7 +12,7 @@
             <h4 class="amount_header">Please choose a quantity: </h4>
             <br/>
 
-              <span>$<%= number_with_precision(@campaign.fixed_payment_amount, precision: 2) %>&nbsp; x &nbsp;</span>
+              <span><%= short_price(@campaign.fixed_payment_amount, '$', 2) %>&nbsp; x &nbsp;</span>
               <select id="quantity" name="quantity" style="width:65px">
                 <option value="01" selected>01</option>
                 <option value="02">02</option>
@@ -25,7 +25,7 @@
                 <option value="09">09</option>
                 <option value="10">10</option>
               </select>
-              <span>&nbsp; = &nbsp;$<span id="total"><%= number_with_precision(@campaign.fixed_payment_amount, precision: 2) %></span></span>
+              <span>&nbsp; = &nbsp;$<span id="total"><%= short_price(@campaign.fixed_payment_amount, '', 2) %></span></span>
 
             </div>
 
@@ -40,7 +40,7 @@
               <input id="amount" type="text" name="amount" value="<%= short_price(@reward.price) if @reward %>"/>&nbsp;&nbsp;
               <span style="position:absolute">$</span>
             </div>
-            <span class="minimum">Minimum is $<%= number_with_precision(@campaign.min_payment_amount, precision: 2) %></span>
+            <span class="minimum">Minimum is <%= short_price(@campaign.min_payment_amount, '$', 2) %></span>
             <label class="error hide"></label>
             </div>
             <input id="quantity" type="hidden" name="quantity" value="1"/>
@@ -51,7 +51,7 @@
             <div id="reward_select" data-reference="<%= @campaign.reward_reference %>">
             <h4>Select your <%= @campaign.reward_reference %>: </h4>
             <ul>
-              <li class="reward_option active <%= raw('hide') if @reward %> clearfix" data-id="0" data-price="<%= short_price(@campaign.min_payment_amount) %>">
+              <li class="reward_option active <%= raw('hide') if @reward %> clearfix" data-id="0" data-price="<%= number_with_precision(@campaign.min_payment_amount, precision: 2) %>">
                   <input class="reward_input" type="radio" name="reward" value="0">
                   <label class="price"></label>
                   <div class="reward_description">
@@ -61,9 +61,9 @@
               </li>
               <% @campaign.rewards.order("price ASC").each do |reward| %>
               <% if reward.visible? %>
-                <li class="reward_option <%= raw('active') unless reward.sold_out? %> <%= ((@reward.id == reward.id) ? raw('selected') : raw('hide')) if @reward %> clearfix" data-id="<%= reward.id %>" data-price="<%= short_price(reward.price) %>">
+                <li class="reward_option <%= raw('active') unless reward.sold_out? %> <%= ((@reward.id == reward.id) ? raw('selected') : raw('hide')) if @reward %> clearfix" data-id="<%= reward.id %>" data-price="<%= number_with_precision(reward.price, precision: 2) %>">
                   <input class="reward_input" type="radio" name="reward" value="<%= reward.id %>" <%= raw('disabled') if reward.sold_out? %><%= raw('checked="checked"') if @reward && @reward.id == reward.id %>>
-                  <label class="price">$<%= short_price(reward.price) %> +</label>
+                  <label class="price"><%= short_price(reward.price, '$') %> +</label>
                   <div class="reward_description">
                     <p class="title"><%= reward.title %></p>
                     <p class="claimed">

--- a/app/views/campaigns/checkout_confirmation.html.erb
+++ b/app/views/campaigns/checkout_confirmation.html.erb
@@ -14,7 +14,7 @@
       <% end%>
       <p>
       <strong>Date:</strong><br/> <%= @payment.created_at.strftime("%m/%d/%Y") %> <br/><br/>
-      <strong>Amount:</strong><br/> $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> <br/><br/>
+      <strong>Amount:</strong><br/> <%= short_price(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, '$', 2) %> <br/><br/>
       <strong>Card:</strong><br/> <%= @payment.card_type %> ************<%= @payment.card_last_four %>
       (<%= @payment.card_expiration_month.to_s + '/' + @payment.card_expiration_year.to_s %>) <br/><br/>
       <% if @campaign.rewards? %>

--- a/app/views/campaigns/checkout_payment.html.erb
+++ b/app/views/campaigns/checkout_payment.html.erb
@@ -134,7 +134,7 @@
           <% end%>
 
           <div class="payment-submit">
-            <button class="btn btn-primary show_loader" type="submit" data-total="<%= number_with_precision(@total, precision: 2) %>" data-loader="payment_form">Confirm payment of $<%= number_with_precision(@total, precision: 2) %></button>
+            <button class="btn btn-primary show_loader" type="submit" data-total="<%= number_with_precision(@total, precision: 2) %>" data-loader="payment_form">Confirm payment of $<%= number_with_precision(@total, :delimiter => ",", precision: 2) %></button>
             <span class="loader" data-loader="payment_form" style="display:none"></span>
             <div id="refresh-msg" style="display: none; color: red; margin-top: 10px">Your payment is being processed! Please do not refresh this page.</div>
           </div>
@@ -162,24 +162,24 @@
           <tr>
           <td width="225">
           <% if @campaign.payment_type == "fixed" %>
-            <p>Subtotal (<%= "#{@quantity} x $#{number_with_precision(@campaign.fixed_payment_amount, precision: 2)}" %>)</p>
+            <p>Subtotal (<%= "#{@quantity} x #{short_price(@campaign.fixed_payment_amount, '$', 2)}" %>)</p>
           <% else %>
             <p>Subtotal</p>
           <% end %>
           </td>
-          <td style="text-align: right"><p>$<%= number_with_precision(@amount, precision: 2) %> </p></td>
+          <td style="text-align: right"><p><%= short_price(@amount, '$', 2) %></p></td>
           </tr>
 
           <% if @fee > 0 %>
           <tr>
           <td width="225"><p>Processing Fee</p></td>
-          <td style="text-align: right"><p>$<%= number_with_precision(@fee, precision: 2) %></p></td>
+          <td style="text-align: right"><p><%= short_price(@fee, '$', 2) %></p></td>
           </tr>
           <% end %>
 
           <tr>
           <td width="225"><p><strong>Total</strong></p></td>
-          <td style="text-align: right"><p><strong>$<%= number_with_precision(@total, precision: 2) %></strong></p></td>
+          <td style="text-align: right"><p><strong><%= short_price(@total, '$', 2) %></strong></p></td>
           </tr>
 
           <% if !@campaign.production_flag %>
@@ -196,7 +196,7 @@
       <div class="well rewards">
         <h4><%= @campaign.reward_reference.titleize %> Selected</h4>
         <% if @reward %>
-          <p><strong><%= "#{@reward.title} ($#{short_price(@reward.price)})" %></strong></p>
+          <p><strong><%= "#{@reward.title} (#{short_price(@reward.price, '$')})" %></strong></p>
           <p><%= @reward.description %></p>
           <p>Estimated Delivery: <%= @reward.delivery_date %></p>
         <% else %>

--- a/app/views/theme/views/campaign.html.erb
+++ b/app/views/theme/views/campaign.html.erb
@@ -169,7 +169,7 @@
             <% if reward.visible? %>
               <li id="rewards_click">
                 <a href="<%= url_for(checkout_amount_path(@campaign, reward: reward.id)) %>"  onclick="<%= 'return false' if reward.sold_out? || @campaign.expired? %>" class="<%= 'disabled' if reward.sold_out? || @campaign.expired? %>">
-                  <p class="price">$<%= number_with_precision(reward.price, precision: (reward.price*100%100==0.0 ? 0 : 2)) %></p>
+                  <p class="price"><%= short_price(reward.price, '$') %></p>
                   <p class="title"><%= reward.title %></p>
                   <% if reward.image_url.present? %><p class="image"><img src="<%= reward.image_url %>"></p><% end %>
                   <p class="description"><%= reward.description %></p>

--- a/app/views/user_mailer/payment_confirmation.html.erb
+++ b/app/views/user_mailer/payment_confirmation.html.erb
@@ -3,7 +3,7 @@ Hi <%= @payment.fullname.split(' ')[0] %>,
 
 <br/><br/>
 
-This is an email receipt for your $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> contribution to <a href="<%= url_for campaign_home_url(@campaign) %>"><%= @campaign.name %></a>. If you have any questions about this campaign, please contact the campaign's organizer at <%= @settings.reply_to_email %><% if @settings.phone_number.present? %> or <%= @settings.phone_number %><% end %>.
+This is an email receipt for your <%= short_price(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, '$', 2) %> contribution to <a href="<%= url_for campaign_home_url(@campaign) %>"><%= @campaign.name %></a>. If you have any questions about this campaign, please contact the campaign's organizer at <%= @settings.reply_to_email %><% if @settings.phone_number.present? %> or <%= @settings.phone_number %><% end %>.
 
 <br/><br/>
 
@@ -14,7 +14,7 @@ This is an email receipt for your $<%= number_with_precision(@payment.amount.to_
 <strong>Payment Details:</strong><br/>
 Name: <%= @payment.fullname %> <br/>
 Date: <%= @payment.created_at.strftime("%m/%d/%Y") %> <br/>
-Amount: $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> <br/>
+Amount: <%= short_price(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, '$', 2) %> <br/>
 Card: <%= @payment.card_type %> ************<%= @payment.card_last_four %><br/>
 <% if @campaign.rewards? %>
   <%= @campaign.reward_reference.titleize %> Selected: <%= @payment.reward ? @payment.reward.title : 'None' %> <br/>

--- a/app/views/user_mailer/payment_confirmation.text.erb
+++ b/app/views/user_mailer/payment_confirmation.text.erb
@@ -2,7 +2,7 @@
 
 Hi <%= @payment.fullname.split(' ')[0] %>,
 
-This is an email receipt for your $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %> contribution to <%= @campaign.name %> (<%= url_for campaign_home_url(@campaign) %>). If you have any questions about this campaign, please contact the campaign's organizer at <%= @settings.reply_to_email %><% if @settings.phone_number.present? %> or <%= @settings.phone_number %><% end %>.
+This is an email receipt for your <%= short_price(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, '$', 2) %> contribution to <%= @campaign.name %> (<%= url_for campaign_home_url(@campaign) %>). If you have any questions about this campaign, please contact the campaign's organizer at <%= @settings.reply_to_email %><% if @settings.phone_number.present? %> or <%= @settings.phone_number %><% end %>.
 
 <% if !@campaign.production_flag %>
 This campaign is in sandbox mode, your card will not actually be charged.
@@ -12,7 +12,7 @@ Payment Details:
 
 Name: <%= @payment.fullname %>
 Date: <%= @payment.created_at.strftime("%m/%d/%Y") %>
-Amount: $<%= number_with_precision(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, precision: 2) %>
+Amount: <%= short_price(@payment.amount.to_f/100.0 + @payment.user_fee_amount.to_f/100.0, '$', 2) %>
 Card: <%= @payment.card_type %> ************<%= @payment.card_last_four %>
 
 <% if @campaign.rewards? %>


### PR DESCRIPTION
Previously, reward prices were not delimited with commas. This caused confusion for the price on rewards with multi-thousand dollar price points.
