### PR TITLE
Added view payments link to admin navbar

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -28,6 +28,10 @@
              <a href="<%= edit_admin_campaign_path(@campaign) %>"><i class="icon-edit icon-white"></i> Edit campaign</a>
            </li>
 
+           <li>
+             <a href="<%= admin_campaigns_payments_path(@campaign) %>"><i class="icon-list icon-white"></i> View payments</a>
+           </li>
+
            <% if !@campaign.published_flag %>
              <li class="status red show_tooltip" data-placement="bottom" data-title="Visible to ADMINS ONLY">
                Not published


### PR DESCRIPTION
Allows for easy access of campaign payments from the admin navbar when viewing a campaign.

![screen shot 2014-02-01 at 4 49 17 pm](https://f.cloud.github.com/assets/1132438/2059297/df3b39ec-8ba3-11e3-9fab-08b58e64c945.png)
