### PR TITLE
Specify the version of sass as 3.2.13.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem 'ckeditor'
 gem 'aws-sdk'
 gem 'active_model_serializers'
 gem 'momentjs-rails'
+gem 'sass', '3.2.13'
+
 # Front-end
 gem 'bootstrap-sass', '2.1'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
       rspec-expectations (~> 2.13.0)
       rspec-mocks (~> 2.13.0)
     ruby-hmac (0.4.0)
-    sass (3.2.9)
+    sass (3.2.13)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
       sass (>= 3.1.10)


### PR DESCRIPTION
It seems there have some bugs in version 3.3.x.

I have many warnings when I push the tree to Heroku. Like this.

```
       Compiled jquery.ui.all.css  (193ms)  (pid 2062)
       Warning. Error encountered while saving cache /tmp/build_03075db0-0735-449c-a8e3-712028080bbc/tmp/cache/sass/4976cfac0d7960e5a7c0997bd9977f9be1abb388/main.css.scssc: can't dump anonymous class #<Class:0x00000004107170>
```

I googled and found the reason of this issue is cuaused by bugs on sass 3.3.x.
(See also: http://stackoverflow.com/questions/22276991/heroku-error-encountered-while-saving-cache)
